### PR TITLE
Make the gem a noop on Rubies older than 2.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,11 +3,11 @@ name: ci
 on: [push, pull_request]
 
 jobs:
-  build:
+  test:
     runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:
-        ruby: [ 'head', '3.0', '2.7', '2.6' ]
+        ruby: [ 'head', '3.1', '3.0', '2.7', '2.6' ]
         os: [ ubuntu, macos, windows ]
     steps:
     - uses: actions/checkout@v2
@@ -16,6 +16,22 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
     - name: Set up Bundler
-      run: gem install rake-compiler --no-document
+      run: bundle install
     - name: Run test
-      run: rake
+      run: bundle exec rake
+  build:
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      matrix:
+        ruby: [ '2.5' ]
+        os: [ ubuntu, macos, windows ]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+    - name: Set up Bundler
+      run: bundle install
+    - name: Install gem
+      run: bundle exec rake install

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.dll
 *.so
 ChangeLog
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in io-wait.gemspec
 gemspec
+
+gem "rake"
+gem "rake-compiler"
+gem "test-unit"

--- a/Rakefile
+++ b/Rakefile
@@ -3,12 +3,25 @@ require "rake/testtask"
 
 name = "io/wait"
 
-require 'rake/extensiontask'
-extask = Rake::ExtensionTask.new(name) do |x|
-  x.lib_dir.sub!(%r[(?=/|\z)], "/#{RUBY_VERSION}/#{x.platform}")
+if RUBY_VERSION < "2.6"
+  task :compile do
+    # noop
+  end
+
+  task :clean do
+    # noop
+  end
+  libs = []
+else
+  require 'rake/extensiontask'
+  extask = Rake::ExtensionTask.new(name) do |x|
+    x.lib_dir.sub!(%r[(?=/|\z)], "/#{RUBY_VERSION}/#{x.platform}")
+  end
+  libs = ["lib/#{RUBY_VERSION}/#{extask.platform}"]
 end
+
 Rake::TestTask.new(:test) do |t|
-  t.libs = ["lib/#{RUBY_VERSION}/#{extask.platform}"]
+  t.libs = libs
   t.libs << "test/lib"
   t.ruby_opts << "-rhelper"
   t.test_files = FileList["test/**/test_*.rb"]

--- a/ext/io/wait/extconf.rb
+++ b/ext/io/wait/extconf.rb
@@ -1,20 +1,24 @@
 # frozen_string_literal: false
 require 'mkmf'
-target = "io/wait"
 
-have_func("rb_io_wait")
-unless macro_defined?("DOSISH", "#include <ruby.h>")
-  have_header(ioctl_h = "sys/ioctl.h") or ioctl_h = nil
-  fionread = %w[sys/ioctl.h sys/filio.h sys/socket.h].find do |h|
-    have_macro("FIONREAD", [h, ioctl_h].compact)
-  end
-  if fionread
-    $defs << "-DFIONREAD_HEADER=\"<#{fionread}>\""
-    create_makefile(target)
-  end
+if RUBY_VERSION < "2.6"
+  File.write("Makefile", dummy_makefile($srcdir).join(""))
 else
-  if have_func("rb_w32_ioctlsocket", "ruby.h")
-    have_func("rb_w32_is_socket", "ruby.h")
-    create_makefile(target)
+  target = "io/wait"
+  have_func("rb_io_wait")
+  unless macro_defined?("DOSISH", "#include <ruby.h>")
+    have_header(ioctl_h = "sys/ioctl.h") or ioctl_h = nil
+    fionread = %w[sys/ioctl.h sys/filio.h sys/socket.h].find do |h|
+      have_macro("FIONREAD", [h, ioctl_h].compact)
+    end
+    if fionread
+      $defs << "-DFIONREAD_HEADER=\"<#{fionread}>\""
+      create_makefile(target)
+    end
+  else
+    if have_func("rb_w32_ioctlsocket", "ruby.h")
+      have_func("rb_w32_is_socket", "ruby.h")
+      create_makefile(target)
+    end
   end
 end

--- a/io-wait.gemspec
+++ b/io-wait.gemspec
@@ -10,7 +10,6 @@ Gem::Specification.new do |spec|
   spec.description   = %q{Waits until IO is readable or writable without blocking.}
   spec.homepage      = "https://github.com/ruby/io-wait"
   spec.licenses      = ["Ruby", "BSD-2-Clause"]
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.6.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage


### PR DESCRIPTION
Ref: https://github.com/mikel/mail/pull/1439

Some gems depend on io-wait, but still support older rubies,
so they have to chose between droping support or not listing io-wait.

But io-wait could act a a noop on older rubies.

cc @eregon @hsbt @nobu 