### PR TITLE
Fix return value compatibility with Ruby 2.x.

### DIFF
--- a/ext/io/wait/wait.c
+++ b/ext/io/wait/wait.c
@@ -180,7 +180,7 @@ io_wait_readable(int argc, VALUE *argv, VALUE io)
 
 #ifndef HAVE_RB_IO_WAIT
     if (wait_for_single_fd(fptr, RB_WAITFD_IN, tv)) {
-	return io;
+        return io;
     }
     return Qnil;
 #else
@@ -216,7 +216,7 @@ io_wait_writable(int argc, VALUE *argv, VALUE io)
 #ifndef HAVE_RB_IO_WAIT
     tv = get_timeout(argc, argv, &timerec);
     if (wait_for_single_fd(fptr, RB_WAITFD_OUT, tv)) {
-	return io;
+        return io;
     }
     return Qnil;
 #else
@@ -333,20 +333,20 @@ io_wait(int argc, VALUE *argv, VALUE io)
 
     GetOpenFile(io, fptr);
     for (i = 0; i < argc; ++i) {
-	if (SYMBOL_P(argv[i])) {
-	    event |= wait_mode_sym(argv[i]);
-	}
-	else {
-	    *(tv = &timerec) = rb_time_interval(argv[i]);
-	}
+        if (SYMBOL_P(argv[i])) {
+            event |= wait_mode_sym(argv[i]);
+        }
+        else {
+            *(tv = &timerec) = rb_time_interval(argv[i]);
+        }
     }
     /* rb_time_interval() and might_mode() might convert the argument */
     rb_io_check_closed(fptr);
     if (!event) event = RB_WAITFD_IN;
     if ((event & RB_WAITFD_IN) && rb_io_read_pending(fptr))
-	return Qtrue;
+        return Qtrue;
     if (wait_for_single_fd(fptr, event, tv))
-	return io;
+        return io;
     return Qnil;
 #else
     VALUE timeout = Qundef;


### PR DESCRIPTION
Ruby 2.x behaviour returned IO instance from `IO#wait`. But this isn't useful behaviour - it's better to know the exact mask of ready events, so I changed it to return event mask where possible. We defined the return value as truthy and falsey which allows of this. However, I felt like I shouldn't have changed the previously documented behaviour even if it works.

Therefore, this PR reworks the existing interface to return `IO` instances where it did in Ruby 2.7 and retains the new code path for 3.x which returns the event mask only when the new `wait(mask, timeout)` method signature is used.