### PR TITLE
Use GITHUB_OUTPUT instead of deprecated set-output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,8 @@ jobs:
         rake build:sha512
         cat pkg/SHA512
         gem=${GITHUB_REPOSITORY#*/}
-        echo "::set-output name=gem::$gem"
-        echo "::set-output name=pkg::$gem-${RUNNING_OS%-*}"
+        echo "gem=$gem" >> $GITHUB_OUTPUT
+        echo "pkg=$gem-${RUNNING_OS%-*}" >> $GITHUB_OUTPUT
       env:
         RUNNING_OS: ${{matrix.platform || matrix.os}}
       if: ${{matrix.ruby == '3.1' || matrix.platform}}


### PR DESCRIPTION
Hi. 👋 I've noticed reading the post below that the `set-output` has been deprecated.
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

We do not have the apparent log because the deprecation warning has been in effect since October 2022 while the last execution was in July. I hope this is going to be of help though. How does it sound?