### PR TITLE
Remove usage of IO internals.

### DIFF
--- a/ext/io/wait/extconf.rb
+++ b/ext/io/wait/extconf.rb
@@ -6,6 +6,7 @@ if RUBY_VERSION < "2.6"
 else
   target = "io/wait"
   have_func("rb_io_wait")
+  have_func("rb_io_descriptor")
   unless macro_defined?("DOSISH", "#include <ruby.h>")
     have_header(ioctl_h = "sys/ioctl.h") or ioctl_h = nil
     fionread = %w[sys/ioctl.h sys/filio.h sys/socket.h].find do |h|

--- a/ext/io/wait/wait.c
+++ b/ext/io/wait/wait.c
@@ -87,8 +87,15 @@ io_nread(VALUE io)
     rb_io_check_readable(fptr);
     len = rb_io_read_pending(fptr);
     if (len > 0) return INT2FIX(len);
-    if (!FIONREAD_POSSIBLE_P(fptr->fd)) return INT2FIX(0);
-    if (ioctl(fptr->fd, FIONREAD, &n)) return INT2FIX(0);
+
+#ifdef HAVE_RB_IO_DESCRIPTOR
+    int fd = rb_io_descriptor(io);
+#else
+    int fd = fptr->fd;
+#endif
+
+    if (!FIONREAD_POSSIBLE_P(fd)) return INT2FIX(0);
+    if (ioctl(fd, FIONREAD, &n)) return INT2FIX(0);
     if (n > 0) return ioctl_arg2num(n);
     return INT2FIX(0);
 }


### PR DESCRIPTION
See https://github.com/ruby/ruby/pull/6511 for more details.

cc @KJTsanaktsidis